### PR TITLE
typeface로 고정되는 버그처리

### DIFF
--- a/BorderTextView/src/main/java/com/mspark/bordertextview/BorderEditText.kt
+++ b/BorderTextView/src/main/java/com/mspark/bordertextview/BorderEditText.kt
@@ -2,6 +2,7 @@ package com.mspark.bordertextview
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Typeface
 import android.util.AttributeSet
 
 class BorderEditText : androidx.appcompat.widget.AppCompatEditText {
@@ -33,5 +34,10 @@ class BorderEditText : androidx.appcompat.widget.AppCompatEditText {
 
     fun setStrokeWidth(width: Int) {
         borderComponent.setStrokeWidth(width)
+    }
+
+    fun setTypeFace(typeface: Typeface) {
+        this.typeface = typeface
+        borderComponent.setTypeface(typeface)
     }
 }

--- a/BorderTextView/src/main/java/com/mspark/bordertextview/BorderTextComponent.kt
+++ b/BorderTextView/src/main/java/com/mspark/bordertextview/BorderTextComponent.kt
@@ -4,6 +4,7 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
+import android.graphics.Typeface
 import android.text.TextPaint
 import android.util.AttributeSet
 import android.view.Gravity
@@ -13,6 +14,8 @@ class BorderTextComponent(private val view: TextView) {
     private var stroke = false
     private var strokeWidth = 0.0f
     private var strokeColor = 0
+    private var typeface: Typeface? = null
+
 
     private val strokePaint: Paint by lazy {
         TextPaint()
@@ -45,7 +48,7 @@ class BorderTextComponent(private val view: TextView) {
         strokePaint.apply {
             strokeWidth = this@BorderTextComponent.strokeWidth
             textSize = view.textSize
-            typeface = view.typeface
+            typeface = this@BorderTextComponent.typeface
             color = strokeColor
         }
 
@@ -98,6 +101,11 @@ class BorderTextComponent(private val view: TextView) {
             stroke = true
         }
         strokeWidth = width.toFloat()
+        view.invalidate()
+    }
+
+    fun setTypeface(typeface: Typeface) {
+        this.typeface = typeface
         view.invalidate()
     }
 }

--- a/BorderTextView/src/main/java/com/mspark/bordertextview/BorderTextView.kt
+++ b/BorderTextView/src/main/java/com/mspark/bordertextview/BorderTextView.kt
@@ -2,6 +2,7 @@ package com.mspark.bordertextview
 
 import android.content.Context
 import android.graphics.Canvas
+import android.graphics.Typeface
 import android.util.AttributeSet
 
 class BorderTextView : androidx.appcompat.widget.AppCompatTextView {
@@ -34,6 +35,11 @@ class BorderTextView : androidx.appcompat.widget.AppCompatTextView {
 
     fun setStrokeWidth(width: Int) {
         borderComponent.setStrokeWidth(width)
+    }
+
+    fun setTypeFace(typeface: Typeface) {
+        this.typeface = typeface
+        borderComponent.setTypeface(typeface)
     }
 
 }

--- a/app/src/main/java/com/mspark/bordertextview/MainActivity.kt
+++ b/app/src/main/java/com/mspark/bordertextview/MainActivity.kt
@@ -1,11 +1,11 @@
 package com.mspark.bordertextview
 
+import android.graphics.Typeface
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
-import android.util.Log
 import android.view.Gravity
 import android.widget.Button
-import android.widget.EditText
+import java.io.File
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -31,6 +31,24 @@ class MainActivity : AppCompatActivity() {
 
                 gravity = Gravity.RIGHT or Gravity.CENTER_VERTICAL
             }
+        }
+
+    }
+
+
+    /**
+     * 삼성폰 안드로이드 14, One Ui 6.1에서 발견된 시스템 폰트를 바꿨을 경우 시스템 폰트의 typeface로 고정되는 버그 처리
+     * 이 함수를 써서 TextView나 EditText의 font를 변경해야함.
+     */
+    private fun setTextFont(fontFileName: String) {
+
+        val typeface = Typeface.createFromAsset(
+            assets,
+            "fonts" + File.separator + fontFileName
+        )
+
+        if (typeface != null) {
+            findViewById<BorderTextView>(R.id.programmatic_text_view).setTypeFace(typeface)
         }
     }
 }


### PR DESCRIPTION
삼성폰 안드로이드 14, One Ui 6.1에서 발견된 시스템 폰트를 바꿨을 경우 시스템 폰트의 typeface로 고정되는 버그 처리